### PR TITLE
Fix group library fetching issue

### DIFF
--- a/src/bib.ts
+++ b/src/bib.ts
@@ -49,6 +49,19 @@ export class BibManager {
                 body: JSON.stringify(payload),
             });
             const json = await response.json();
+            
+            // Handle JSON-RPC errors
+            if (json.error) {
+                vscode.window.showErrorMessage(`Better BibTeX error: ${json.error.message || 'Unknown error'}`);
+                return '';
+            }
+            
+            // Ensure result is a string
+            if (typeof json.result !== 'string') {
+                vscode.window.showErrorMessage('Better BibTeX returned invalid result format');
+                return '';
+            }
+            
             return json.result;
 
         } catch (error) {
@@ -260,8 +273,8 @@ export class BibManager {
             // Get BibTeX entry
 
             const bibEntry = await this.bbtExport(item);
-            // if bibEntry is empty, return (probably could not connect to BBT server)
-            if (bibEntry.trim() === '') {
+            // if bibEntry is empty or undefined, return (probably could not connect to BBT server)
+            if (!bibEntry || bibEntry.trim() === '') {
                return;
             }
 

--- a/src/bib.ts
+++ b/src/bib.ts
@@ -35,8 +35,8 @@ export class BibManager {
             params: {
                 citekeys: [item.citeKey],
                 translator: this.translator,
-            },
-            id: item.libraryID,
+                libraryID: item.libraryID
+            }
         };
 
         try {


### PR DESCRIPTION
This PR solves #7 by correcting payload structure.
See the syntax for parameter `libraryID` of method `item.export` in [API](https://retorque.re/zotero-better-bibtex/exporting/json-rpc/index.html).
Also, added some error handling.
Thank you.